### PR TITLE
Minor updates

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,10 +16,15 @@ categories:
       - improvement
   - title: 🐛 Bug Fixes
     labels:
-      - bugfix  
-  - title: 📁 Has migrations
+      - bug
+  - title: 📁 Has Migrations
     labels:
       - has-migration
+  - title: 📦 Security and Dependency Updates
+    labels:
+      - security
+      - dependencies
+  - title: ✍️ Other Changes
 
 exclude-labels:
   - linting
@@ -49,6 +54,9 @@ autolabeler:
   - label: improvement
     branch:
       - '/improvement\/.+/'
+  - label: security
+    branch:
+      - '/security\/.+/'
   - label: has-frontend
     files:
       - '*.js'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,35 +8,18 @@ no-changes-template: '### No changes'
 template: $CHANGES
 
 categories:
-  - title: 💥 Breaking changes
+  - title: ✨ Features
     labels:
-      - breaking
-  - title: 🚀 New Features and Improvements
+      - feature  
+  - title: 🛠️ Improvements
     labels:
       - improvement
-      - feature
   - title: 🐛 Bug Fixes
     labels:
-      - bug
-      - fix
-      - bugfix
-  - title: 🛡️ Security
+      - bugfix  
+  - title: 📁 Has migrations
     labels:
-      - security
-  - title: 👻 Maintenance
-    labels:
-      - chore
-      - internal
-      - maintenance
-  - title: 🚦 Tests
-    labels:
-      - test
-      - tests
-  - title: 📦 Dependency Updates
-    labels:
-      - dependencies
-    collapse-after: 5
-  - title: ✍️ Other Changes
+      - has-migration
 
 exclude-labels:
   - linting
@@ -59,12 +42,13 @@ version-resolver:
 autolabeler:
   - label: bug
     branch:
-      - '/fix\/.+/'
       - '/bugfix\/.+/'
-      - '/hotfix\/.+/'
   - label: feature
     branch:
       - '/feature\/.+/'
+  - label: improvement
+    branch:
+      - '/improvement\/.+/'
   - label: has-frontend
     files:
       - '*.js'


### PR DESCRIPTION
Basically a clean up to focus on what we want to use straight out of the gate and removing anything else. We can always add to this in the future. The only thing devs will need to do different is use the new `improvement/` branch prefix for improvements. So now there will be three different types of branches easily determined by the label given to the associated card in Trello:
- `feature/`
- `improvement/`
- `bugfix/`