### PR TITLE
Publish release is failing when release logs are long

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,47 +9,31 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
     steps:
-      - name: "Get Releases"
-        id: get_releases
-        uses: octokit/request-action@v2.x
-        with:
-          route: GET /repos/${{ github.repository }}/releases
-          query: |
-            per_page=10
-
-      - name: "Get Draft Release ID"
-        id: draft_release_id
+      - name: "Find and Publish Draft Release"
         uses: actions/github-script@v7
         with:
-          result-encoding: string
           script: |
-            const data = process.env.DATA;
-            const releases = JSON.parse(data);
-            const draftReleases = releases.filter(release => release.draft);
+            const { data: releases } = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 10
+            });
 
-            if (draftReleases.length === 0) {
-              console.log("::error::No draft releases found. Cancelling workflow.");
-              process.exit(1);
+            const draftRelease = releases.find(release => release.draft);
+
+            if (!draftRelease) {
+              core.setFailed("No draft releases found. Cancelling workflow.");
+              return;
             }
 
-            const releaseId = draftReleases[0].id;
+            console.log(`Found draft release: ${draftRelease.name} (ID: ${draftRelease.id})`);
 
-            if (!releaseId) {
-              console.log("::error::No draft release ID found. Cancelling workflow.");
-              process.exit(1);
-            }
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: draftRelease.id,
+              draft: false
+            });
 
-            return releaseId;
-        env:
-          DATA: ${{ steps.get_releases.outputs.data }}
-
-      - name: "Publish Draft Release"
-        if: ${{ !failure() && steps.draft_release_id.outputs.result }}
-        uses: octokit/request-action@v2.x
-        with:
-          route: PATCH /repos/${{ github.repository }}/releases/${{ steps.draft_release_id.outputs.result }}
-          draft: false
+            console.log(`Successfully published release: ${draftRelease.name}`);


### PR DESCRIPTION
The "Publish Draft Release" workflow fails intermittently because the reusable workflow passes the entire releases JSON response as an environment variable (DATA).

When the release notes are extensive (which they are - each release has detailed changelogs with many PRs), the combined size of 10 releases exceeds Linux's ARG_MAX limit (~2MB on most systems), causing the error:

```
Argument list too long
```

This completely avoids the "Argument list too long" error because the release data never touches environment variables - it's processed entirely within the JavaScript runtime.